### PR TITLE
Multus Thick plugin Chart

### DIFF
--- a/.github/workflows/helm_test_multus_thick.yml
+++ b/.github/workflows/helm_test_multus_thick.yml
@@ -1,0 +1,43 @@
+name: Multus Chart Test
+
+on:
+  push:
+    paths:
+        - 'multus-thick/**'
+        - '.github/workflows/helm_test_multus_thick.yml'
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:  # Allows manually triggering the workflow
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'v3.12.0' # specify the Helm version you want to use
+
+      - name: Set up Kubernetes (kind)
+        uses: helm/kind-action@v1.2.0
+        with:
+          version: v0.17.0 # specify the kind version you want to use
+
+      - name: Helm Lint Multus-thick
+        run: helm lint multus-thick
+
+      - name: Install Helm chart multus-thick
+        run: helm install --wait --timeout 60s multus-release ./multus-thick
+
+      - name: Run Helm tests
+        run: helm test multus-release --timeout 60s
+
+      - name: Delete Helm release
+        run: helm uninstall multus-release

--- a/.github/workflows/helm_test_multus_thick.yml
+++ b/.github/workflows/helm_test_multus_thick.yml
@@ -1,4 +1,4 @@
-name: Multus Chart Test
+name: Multus-thick Chart Test
 
 on:
   push:

--- a/multus-thick/.helmignore
+++ b/multus-thick/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/multus-thick/Chart.yaml
+++ b/multus-thick/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: multus-thick
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+home: https://github.com/k8snetworkplumbingwg/helm-charts
+icon: https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/doc/images/Multus.png
+sources:
+  - https://github.com/k8snetworkplumbingwg/multus-cni
+maintainers:
+  - name: Network Plumbing Group
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v4.1.0"

--- a/multus-thick/README.md.gotmpl
+++ b/multus-thick/README.md.gotmpl
@@ -1,0 +1,10 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/multus-thick/templates/NOTES.txt
+++ b/multus-thick/templates/NOTES.txt
@@ -1,0 +1,1 @@
+good luck

--- a/multus-thick/templates/_helpers.tpl
+++ b/multus-thick/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "multus-thick.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "multus-thick.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "multus-thick.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "multus-thick.labels" -}}
+helm.sh/chart: {{ include "multus-thick.chart" . }}
+{{ include "multus-thick.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "multus-thick.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "multus-thick.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "multus-thick.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "multus-thick.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/multus-thick/templates/clusterRole.yaml
+++ b/multus-thick/templates/clusterRole.yaml
@@ -1,0 +1,41 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "16" ) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+rules:
+  - apiGroups: ["k8s.cni.cncf.io"]
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/status
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+{{- end }}

--- a/multus-thick/templates/clusterRole.yaml
+++ b/multus-thick/templates/clusterRole.yaml
@@ -29,9 +29,12 @@ rules:
       - pods/status
     verbs:
       - get
+      - list
       - update
+      - watch
   - apiGroups:
       - ""
+      - events.k8s.io
     resources:
       - events
     verbs:

--- a/multus-thick/templates/clusterRoleBinding.yaml
+++ b/multus-thick/templates/clusterRoleBinding.yaml
@@ -23,5 +23,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name }}
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/multus-thick/templates/clusterRoleBinding.yaml
+++ b/multus-thick/templates/clusterRoleBinding.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "16" ) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Chart.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: kube-system
+{{- end }}

--- a/multus-thick/templates/configMap.yaml
+++ b/multus-thick/templates/configMap.yaml
@@ -1,0 +1,12 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-multus-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: multus-thick
+    {{- include "multus-thick.labels" . | nindent 4 }}
+data:
+  daemon-config.json: |
+    {{ .Values.config | indent 4 }}

--- a/multus-thick/templates/crds/net-def.yaml
+++ b/multus-thick/templates/crds/net-def.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: network-attachment-definitions.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  scope: Namespaced
+  names:
+    plural: network-attachment-definitions
+    singular: network-attachment-definition
+    kind: NetworkAttachmentDefinition
+    shortNames:
+      - net-attach-def
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: 'NetworkAttachmentDefinition is a CRD schema specified by the Network Plumbing
+            Working Group to express the intent for attaching pods to one or more logical or physical
+            networks. More information available at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this represen
+                tation of an object. Servers should convert recognized schemas to the
+                latest internal value, and may reject unrecognized values. More info:
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'NetworkAttachmentDefinition spec defines the desired state of a network attachment'
+              type: object
+              properties:
+                config:
+                  description: 'NetworkAttachmentDefinition config is a JSON-formatted CNI configuration'
+                  type: string

--- a/multus-thick/templates/daemonSet.yaml
+++ b/multus-thick/templates/daemonSet.yaml
@@ -73,7 +73,7 @@ spec:
                   fieldPath: spec.nodeName
       initContainers:
         - name: install-multus-binary
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           command:
             - "cp"
             - "/usr/src/multus-cni/bin/multus-shim"

--- a/multus-thick/templates/daemonSet.yaml
+++ b/multus-thick/templates/daemonSet.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name }}-{{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: multus-thick
+    {{- include "multus-thick.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: multus-thick
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: multus-thick
+        {{- include "multus-thick.labels" . | nindent 8 }}
+    spec:
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      hostPID: true
+      {{- with .Values.tolerations}}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      containers:
+        - name: kube-multus
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
+          {{- with .Values.resources}}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            privileged: true
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: cni
+              mountPath: /host/etc/cni/net.d
+            # multus-daemon expects that cnibin path must be identical between pod and container host.
+            # e.g. if the cni bin is in '/opt/cni/bin' on the container host side, then it should be mount to '/opt/cni/bin' in multus-daemon,
+            # not to any other directory, like '/opt/bin' or '/usr/bin'.
+            - name: cnibin
+              mountPath: /opt/cni/bin
+            - name: host-run
+              mountPath: /host/run
+            - name: host-var-lib-cni-multus
+              mountPath: /var/lib/cni/multus
+            - name: host-var-lib-kubelet
+              mountPath: /var/lib/kubelet
+              mountPropagation: HostToContainer
+            - name: host-run-k8s-cni-cncf-io
+              mountPath: /run/k8s.cni.cncf.io
+            - name: host-run-netns
+              mountPath: /run/netns
+              mountPropagation: HostToContainer
+            - name: multus-daemon-config
+              mountPath: /etc/cni/net.d/multus.d
+              readOnly: true
+            - name: hostroot
+              mountPath: /hostroot
+              mountPropagation: HostToContainer
+          env:
+            - name: MULTUS_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+      initContainers:
+        - name: install-multus-binary
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
+          command:
+            - "cp"
+            - "/usr/src/multus-cni/bin/multus-shim"
+            - "/host/opt/cni/bin/multus-shim"
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "15Mi"
+          securityContext:
+            privileged: true
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - name: cnibin
+              mountPath: /host/opt/cni/bin
+              mountPropagation: Bidirectional
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: cnibin
+          hostPath:
+            path: /opt/cni/bin
+        - name: hostroot
+          hostPath:
+            path: /
+        - name: multus-daemon-config
+          configMap:
+            name: {{ .Release.Name }}-multus-config
+            items:
+              - key: daemon-config.json
+                path: daemon-config.json
+        - name: host-run
+          hostPath:
+            path: /run
+        - name: host-var-lib-cni-multus
+          hostPath:
+            path: /var/lib/cni/multus
+        - name: host-var-lib-kubelet
+          hostPath:
+            path: /var/lib/kubelet
+        - name: host-run-k8s-cni-cncf-io
+          hostPath:
+            path: /run/k8s.cni.cncf.io
+        - name: host-run-netns
+          hostPath:
+            path: /run/netns/

--- a/multus-thick/templates/serviceAccount.yaml
+++ b/multus-thick/templates/serviceAccount.yaml
@@ -1,0 +1,21 @@
+# Copyright 2020 K8s Network Plumbing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- if or ( gt .Capabilities.KubeVersion.Major "1" ) ( ge .Capabilities.KubeVersion.Minor "16" ) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+

--- a/multus-thick/values.yaml
+++ b/multus-thick/values.yaml
@@ -1,0 +1,46 @@
+# Default values for multus-thick.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+
+image:
+  # -- Repository for the Multus image.
+  repository: ghcr.io/k8snetworkplumbingwg/multus-cni
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  # -- Tag of the Multus image.
+  tag: "snapshot-thick"
+
+serviceAccount:
+  name: multus-thick
+
+# -- Resources for the Multus pod.
+resources:
+  requests:
+    cpu: "100m"
+    memory: "50Mi"
+  limits:
+    cpu: "100m"
+    memory: "50Mi"
+
+# -- Toleration definitions
+tolerations:
+  - operator: Exists
+    effect: NoSchedule
+  - operator: Exists
+    effect: NoExecute
+
+affinity: {}
+
+# -- multus json config
+config: |
+  {
+        "chrootDir": "/hostroot",
+        "cniVersion": "0.3.1",
+        "logLevel": "verbose",
+        "logToStderr": true,
+        "cniConfigDir": "/host/etc/cni/net.d",
+        "multusAutoconfigDir": "/host/etc/cni/net.d",
+        "multusConfigFile": "auto",
+        "socketDir": "/host/run/multus/"
+      }


### PR DESCRIPTION
### Summary
This PR introduces a new Helm chart specifically for the multus-thick plugin. In addition to the Helm chart, it includes a GitHub Action for automated testing and linting.

### Key Changes

1. New Helm Chart for multus-thick:
    -  This chart is separate from the existing multus chart to simplify the structure and avoid the complexity of using conditional (if) statements within a single chart.
     - The chart is designed to focus solely on the deployment of the multus-thick plugin, making it easier to maintain and customize without handling multiple plugin configurations in one place.
3. GitHub Action for Testing/Linting:
    - Adds a CI workflow using GitHub Actions to automatically run Helm linting and testing on each PR or push.
    - Ensures that the chart adheres to best practices and doesn't introduce any issues during development.
### Rationale
- Simpler Chart Structure: By breaking out the multus-thick plugin into its own Helm chart, the chart logic is cleaner and easier to maintain. This avoids the need for complex if conditions that would otherwise be required to handle both multus-thick and multus-thin in a single chart.
- Improved CI/CD: The addition of GitHub Actions for linting and testing ensures that the chart is continuously validated against best practices and that any issues are caught early during the development process.
### Testing & Validation
- The GitHub Action included in this PR automatically runs Helm linting and basic testing, ensuring that the chart is properly validated before merging.
- Manual testing has also been done to ensure that the multus-thick plugin deploys correctly in various environments.
### Next Steps
- Future iterations may include additional testing or enhancements based on feedback, but the separation of the thick and thin plugins into their own charts should reduce complexity moving forward.